### PR TITLE
Update bip-0101.mediawiki

### DIFF
--- a/bip-0101.mediawiki
+++ b/bip-0101.mediawiki
@@ -122,4 +122,4 @@ Simplified Payment Verification software is not affected, unless it makes assump
 
 ==Implementation==
 
-https://github.com/gavinandresen/bitcoinxt/tree/blocksize_fork
+https://github.com/gavinandresen/bitcoin-git/tree/blocksize_fork_0.12


### PR DESCRIPTION
Fixed link from refering to Bitcoin XT branch to Bitcoin Core branch.